### PR TITLE
[Docker] Docker compose file refactored with new images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.6'
 services:
   bloqCat-api:
-    image: aldekal/bloqcat-api:bloqcat
+    image: ghcr.io/leqo-framework/bloqcat:sha-463a509
     ports:
       - "5000:5000"
     networks:
       - default
   ##### Winery ###
   winery:
-    image: aldekal/winery:bloqcat
+    image: ghcr.io/leqo-framework/winery:sha-2f7b64a
     environment:
       WINERY_HOSTNAME: ${PUBLIC_HOSTNAME}
       WORKFLOWMODELER_HOSTNAME: ${PUBLIC_HOSTNAME}
@@ -40,7 +40,7 @@ services:
     networks:
       - default
   qc-atlas-ui:
-    image: aldekal/qc-atlas-ui:bloqcat
+    image: ghcr.io/leqo-framework/qc-atlas-ui:sha-7c11e0c
     depends_on:
       - config-server
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       WORKFLOWMODELER_HOSTNAME: ${PUBLIC_HOSTNAME}
       TOPOLOGYMODELER_HOSTNAME: ${PUBLIC_HOSTNAME}
       CONTAINER_HOSTNAME: ${PUBLIC_HOSTNAME}
-      WINERY_REPOSITORY_URL: https://github.com/LEQO-Framework/winery
+      WINERY_REPOSITORY_URL: https://github.com/LEQO-Framework/bloqCat-modeling
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       WORKFLOWMODELER_HOSTNAME: ${PUBLIC_HOSTNAME}
       TOPOLOGYMODELER_HOSTNAME: ${PUBLIC_HOSTNAME}
       CONTAINER_HOSTNAME: ${PUBLIC_HOSTNAME}
-      WINERY_REPOSITORY_URL: https://github.com/aldekal/bloqCat-modeling
+      WINERY_REPOSITORY_URL: https://github.com/LEQO-Framework/winery
     ports:
       - '8080:8080'
     networks:


### PR DESCRIPTION
Docker compose refactored to use images in the LEQO organisation.
Images changed : aldekal/bloqcat-api:bloqcat --> ghcr.io/leqo-framework/bloqcat:sha-463a509
aldekal/winery:bloqcat --> ghcr.io/leqo-framework/winery:sha-2f7b64a
aldekal/qc-atlas-ui:bloqcat --> ghcr.io/leqo-framework/qc-atlas-ui:sha-7c11e0c

Image for Qc-Atlas-API will be replaced once issues are fixed.

Tested by using the docker compose file in Bloqcat Framework to start all containers.
All containers running successfully by pulling images from Leqo framework instead of Aldekal.
<img width="724" alt="runningcontainers" src="https://github.com/user-attachments/assets/6d6164a0-dfda-4fae-adf1-3b9c32d9f4d9" />
